### PR TITLE
Fix NBT serialization: pack() saves wrong action list

### DIFF
--- a/src/main/kotlin/me/senseiwells/puppet/action/PuppetPlayerActions.kt
+++ b/src/main/kotlin/me/senseiwells/puppet/action/PuppetPlayerActions.kt
@@ -396,7 +396,7 @@ class PuppetPlayerActions(
             this.usingHeld,
             this.loop,
             this.action,
-            this.actions
+            this.chained
         )
     }
 


### PR DESCRIPTION
The `pack()` method was serializing `this.actions` (temporary actions) while `unpack()` was deserializing into `this.chained` (persistent action sequence), causing chained actions to be lost on save/load.

**Changes**
- Changed `PuppetPlayerActions.pack()` line 399 to serialize `this.chained` instead of `this.actions`

**Context**
- `actions`: Ephemeral non-immediate actions that execute once and are removed
- `chained`: Persistent action sequence with loop support, indexed by the `action` field
- The `unpack()` method was already correctly deserializing into `this.chained`

```kotlin
// Before
internal fun pack(): Packed {
    return Packed(
        // ... other fields
        this.actions  // ❌ Wrong list
    )
}

// After  
internal fun pack(): Packed {
    return Packed(
        // ... other fields
        this.chained  // ✅ Correct list
    )
}
```